### PR TITLE
Add env context support and output for dev/prod separation

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -4,10 +4,17 @@ import { VpcStack } from '../lib/vpc-stack';
 import { Ec2Stack } from '../lib/ec2-stack';
 
 const app = new cdk.App();
-const vpcStack = new VpcStack(app, 'VpcStack', {
+const envName = app.node.tryGetContext('env') || 'dev';
+
+// 共通タグ
+cdk.Tags.of(app).add('env', envName);
+
+// スタック名にenvを含めてdev/prod共存可能に
+const vpcStack = new VpcStack(app, `VpcStack-${envName}`, {
+  envName,
   // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 });
-new Ec2Stack(app, 'Ec2Stack', {
+
+new Ec2Stack(app, `Ec2Stack-${envName}`, {
   vpc: vpcStack.vpc,
-  // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 });

--- a/lib/vpc-stack.ts
+++ b/lib/vpc-stack.ts
@@ -2,10 +2,14 @@ import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 
+interface VpcStackProps extends cdk.StackProps {
+  envName: 'dev' | 'prod';
+}
+
 export class VpcStack extends cdk.Stack {
     public readonly vpc: ec2.Vpc;
 
-    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    constructor(scope: Construct, id: string, props: VpcStackProps) {
         super(scope, id, props);
 
         // NATなし、パブリックサブネットのみのVPC
@@ -19,6 +23,10 @@ export class VpcStack extends cdk.Stack {
                     cidrMask: 24,
                 },
             ],
+        });
+        new cdk.CfnOutput(this, 'CurrentEnv', {
+            value: props.envName,
+            description: 'Current environment name (dev or prod)',
         });
     }
 }


### PR DESCRIPTION
Enable environment-specific stack naming and tagging; output current env for clarity.