### PR TITLE
feat(ecs): introduce EcsStack and replace Ec2Stack reference in app e…

### DIFF
--- a/bin/app.ts
+++ b/bin/app.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 import * as cdk from 'aws-cdk-lib';
 import { VpcStack } from '../lib/vpc-stack';
-import { Ec2Stack } from '../lib/ec2-stack';
+// import { Ec2Stack } from '../lib/ec2-stack';
+import { EcsStack } from '../lib/ecs-stack';
 
 const app = new cdk.App();
 const envName = app.node.tryGetContext('env') || 'dev';
@@ -15,8 +16,14 @@ const vpcStack = new VpcStack(app, `VpcStack-${envName}`, {
   // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 });
 
-new Ec2Stack(app, `Ec2Stack-${envName}`, {
-  vpc: vpcStack.vpc,
+// new Ec2Stack(app, `Ec2Stack-${envName}`, {
+//   vpc: vpcStack.vpc,
+//   envName,
+//   // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
+// });
+
+new EcsStack(app, `EcsStack-${envName}`, {
   envName,
+  vpc: vpcStack.vpc,
   // env: { account: process.env.CDK_DEFAULT_ACCOUNT, region: process.env.CDK_DEFAULT_REGION },
 });

--- a/lib/ecs-stack.ts
+++ b/lib/ecs-stack.ts
@@ -1,0 +1,52 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+
+interface EcsStackProps extends cdk.StackProps {
+    envName: 'dev' | 'prod';
+    vpc: ec2.IVpc;
+}
+
+export class EcsStack extends cdk.Stack {
+    public readonly cluster: ecs.Cluster;
+
+    constructor(scope: Construct, id: string, props: EcsStackProps) {
+        super(scope, id, props);
+
+        this.cluster = new ecs.Cluster(this, 'EcsCluster', {
+            vpc: props.vpc,
+            clusterName: `ecs-cluster-${props.envName}`,
+            containerInsights: props.envName === 'prod',
+        });
+
+        const taskDef = new ecs.FargateTaskDefinition(this, 'NginxTaskDef', {
+            cpu: 256, // 最小クラス
+            memoryLimitMiB: 512, // 最小メモリ
+        });
+
+        taskDef.addContainer('NginxContainer', {
+            // image: ecs.ContainerImage.fromRegistry('nginx:latest'), // Docker Hub
+            // Docker Hub ではなく Public ECR ミラーを使う
+            image: ecs.ContainerImage.fromRegistry('public.ecr.aws/nginx/nginx:stable'),
+            portMappings: [{ containerPort: 80 }],
+            logging: ecs.LogDrivers.awsLogs({ streamPrefix: 'nginx' }),
+        });
+        const sg = new ec2.SecurityGroup(this, 'NginxSvcSg', {
+            vpc: props.vpc,
+            allowAllOutbound: true,
+            description: 'Allow HTTP from anywhere for nginx (training only)',
+        });
+        sg.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(80), 'HTTP');
+
+        // サービス（単一タスク、ALBなし、Public直当て）
+        new ecs.FargateService(this, 'NginxService', {
+            cluster: this.cluster,
+            taskDefinition: taskDef,
+            desiredCount: 1,
+            vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+            assignPublicIp: true,
+            securityGroups: [sg],
+        });
+    }
+}


### PR DESCRIPTION
…ntrypoint

- Added new `EcsStack` with minimal Fargate service running public ECR nginx image
- Updated `bin/app.ts` to use `EcsStack` instead of `Ec2Stack` for deployment
- Basic setup includes single task in public subnet with security group allowing HTTP
- Intended as a training/demo environment without ALB for initial ECS verification