### PR TITLE
feat(ecs): restructure logging for ECS Fargate (dev/prod, exec logs)

### DIFF
--- a/lib/vpc-stack.ts
+++ b/lib/vpc-stack.ts
@@ -16,6 +16,7 @@ export class VpcStack extends cdk.Stack {
         this.vpc = new ec2.Vpc(this, 'MyVpc', {
             availabilityZones: ['ap-northeast-1c', 'ap-northeast-1d'],
             natGateways: 0, // NAT Gatewayは作らない
+            restrictDefaultSecurityGroup: false,
             subnetConfiguration: [
                 {
                     subnetType: ec2.SubnetType.PUBLIC,


### PR DESCRIPTION
### Summary
Restructure ECS logging and exec log handling via CDK.

### Changes
- Introduced dedicated CloudWatch log groups:
  - /aws/ecs/<cluster>/<service> for container logs
  - /aws/ecs/<cluster>/exec for ECS Exec sessions
- Applied LogRetention (Upsert) to avoid AlreadyExists errors in prod
- Retention policy:
  - dev: container=2w, exec=1w
  - prod: container=6m, exec=1m
- RemovalPolicy.DESTROY only for dev
- Renamed resources:
  - NginxTaskDef -> WebTaskDef
  - NginxSvcSg -> WebSvcSg
  - NginxService -> WebService (serviceName=<env>-web)
- Enabled executeCommandConfiguration on cluster
- Disabled restrictDefaultSecurityGroup in VpcStack

### Notes
This makes log management predictable across environments and 
separates application logs from ECS Exec audit logs.